### PR TITLE
Support billing portal sessions

### DIFF
--- a/lib/client.ex
+++ b/lib/client.ex
@@ -471,6 +471,7 @@ defmodule PinStripe.Client do
   def parse_url("cs_" <> _ = id), do: "/checkout/sessions/#{id}"
   def parse_url("inv_" <> _ = id), do: "/invoices/#{id}"
   def parse_url("evt_" <> _ = id), do: "/events/#{id}"
+  def parse_url("bps_" <> _ = id), do: "/billing_portal/sessions/#{id}"
   def parse_url(url) when is_binary(url), do: url
 
   @doc """
@@ -496,6 +497,7 @@ defmodule PinStripe.Client do
   def entity_to_path(:invoices), do: {:ok, "/invoices"}
   def entity_to_path(:events), do: {:ok, "/events"}
   def entity_to_path(:checkout_sessions), do: {:ok, "/checkout/sessions"}
+  def entity_to_path(:billing_portal_sessions), do: {:ok, "/billing_portal/sessions"}
   def entity_to_path(_), do: {:error, :unrecognized_entity_type}
 
   @doc false

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -276,4 +276,30 @@ defmodule PinStripe.ClientTest do
       end
     end
   end
+
+  describe "billing_portal_sessions" do
+    test "creates a billing portal session" do
+      Mock.stub_create(:billing_portal_sessions, %{
+        "id" => "bps_123",
+        "object" => "billing_portal.session",
+        "url" => "https://billing.stripe.com/session/test_123"
+      })
+
+      result = Client.create(:billing_portal_sessions, %{customer: "cus_123"})
+
+      assert {:ok, %{body: %{"id" => "bps_123", "object" => "billing_portal.session"}}} = result
+    end
+
+    test "reads a billing portal session by ID" do
+      Mock.stub_read("bps_123", %{
+        "id" => "bps_123",
+        "object" => "billing_portal.session",
+        "customer" => "cus_123"
+      })
+
+      result = Client.read("bps_123")
+
+      assert {:ok, %{body: %{"id" => "bps_123"}}} = result
+    end
+  end
 end


### PR DESCRIPTION
## Summary

  - Add support for Stripe Billing Portal Sessions (`bps_` prefix)
  - Enable creating portal sessions via `Client.create(:billing_portal_sessions, %{customer: "cus_123"})`
  - Enable reading portal sessions by ID via `Client.read("bps_123")`

  ## Changes

  - Added `parse_url/1` clause for `bps_` ID prefix → `/billing_portal/sessions/{id}`
  - Added `entity_to_path/1` clause for `:billing_portal_sessions` atom
  - Added tests for create and read operations

  ## Test plan

  - [x] Tests pass for creating billing portal sessions
  - [x] Tests pass for reading billing portal sessions by ID
  - [x] Existing tests unaffected